### PR TITLE
updated to reflect prod and preprod requirements

### DIFF
--- a/ec2-ndl-bcs/main.tf
+++ b/ec2-ndl-bcs/main.tf
@@ -151,7 +151,7 @@ data "template_file" "instance_userdata" {
 }
 
 #-------------------------------------------------------------
-### Create instance - NDL-BCS-300-001
+### Create primary instance - NDL-BCS-300-001
 #-------------------------------------------------------------
 module "create-ec2-instance" {
   source                      = "git::https://github.com/ministryofjustice/hmpps-terraform-modules.git?ref=master//modules//ec2_no_replace_instance"
@@ -166,7 +166,7 @@ module "create-ec2-instance" {
   CreateSnapshot              = false
   tags                        = "${local.tags}"
   key_name                    = "${local.ssh_deployer_key}"
-  root_device_size            = "60"
+  root_device_size            = "${var.bcs_root_size}"
 
   vpc_security_group_ids = [
     "${local.sg_map_ids["sg_mis_app_in"]}",
@@ -194,4 +194,52 @@ resource "aws_route53_record" "instance_ext" {
   type    = "A"
   ttl     = "300"
   records = ["${module.create-ec2-instance.private_ip}"]
+}
+
+#-------------------------------------------------------------
+### Create secondary instance - NDL-BCS-300-002
+#-------------------------------------------------------------
+module "create-ec2-instance-002" {
+  source                      = "git::https://github.com/ministryofjustice/hmpps-terraform-modules.git?ref=master//modules//ec2_no_replace_instance"
+  app_name                    = "${local.environment_identifier}-${local.app_name}-${local.nart_role}-002"
+  ami_id                      = "${data.aws_ami.amazon_ami.id}"
+  instance_type               = "${var.bcs_instance_type}"
+  subnet_id                   = "${local.private_subnet_map["az2"]}"
+  iam_instance_profile        = "${local.instance_profile}"
+  associate_public_ip_address = false
+  monitoring                  = true
+  user_data                   = "${data.template_file.instance_userdata.rendered}"
+  CreateSnapshot              = false
+  tags                        = "${local.tags}"
+  key_name                    = "${local.ssh_deployer_key}"
+  root_device_size            = "${var.bcs_root_size}"
+  deploy = "${var.bcs_deploy_secondary}"
+  vpc_security_group_ids = [
+    "${local.sg_map_ids["sg_mis_app_in"]}",
+    "${local.sg_map_ids["sg_mis_common"]}",
+    "${local.sg_outbound_id}",
+    "${local.sg_map_ids["sg_delius_db_out"]}",
+  ]
+}
+
+#-------------------------------------------------------------
+# Create route53 entry for instance 2
+#-------------------------------------------------------------
+
+resource "aws_route53_record" "instance_002" {
+  count   = "${var.bcs_deploy_secondary ? 1 : 0 }"
+  zone_id = "${local.private_zone_id}"
+  name    = "${local.nart_role}-002.${local.internal_domain}"
+  type    = "A"
+  ttl     = "300"
+  records = ["${module.create-ec2-instance-002.private_ip}"]
+}
+
+resource "aws_route53_record" "instance_ext_002" {
+  count   = "${var.bcs_deploy_secondary ? 1 : 0 }"
+  zone_id = "${local.public_zone_id}"
+  name    = "${local.nart_role}-002.${local.external_domain}"
+  type    = "A"
+  ttl     = "300"
+  records = ["${module.create-ec2-instance-002.private_ip}"]
 }

--- a/ec2-ndl-bcs/output.tf
+++ b/ec2-ndl-bcs/output.tf
@@ -15,3 +15,21 @@ output "primary_dns" {
 output "primary_dns_ext" {
   value = "${aws_route53_record.instance_ext.fqdn}"
 }
+
+# secondary ec2
+output "secondary_instance_id" {
+  value = "${module.create-ec2-instance-002.instance_id}"
+}
+
+output "secondary_private_ip" {
+  value = "${module.create-ec2-instance-002.private_ip}"
+}
+
+# dns
+output "secondary_dns" {
+  value = "${aws_route53_record.instance_002.*.fqdn}"
+}
+
+output "secondary_dns_ext" {
+  value = "${aws_route53_record.instance_ext_002.*.fqdn}"
+}

--- a/ec2-ndl-bcs/variables.tf
+++ b/ec2-ndl-bcs/variables.tf
@@ -11,3 +11,7 @@ variable "environment_type" {
 variable "cloudwatch_log_retention" {}
 
 variable "bcs_instance_type" {}
+
+variable "bcs_root_size" {}
+
+variable "bcs_deploy_secondary" {}

--- a/ec2-ndl-bfs/main.tf
+++ b/ec2-ndl-bfs/main.tf
@@ -166,7 +166,7 @@ module "create-ec2-instance" {
   CreateSnapshot              = false
   tags                        = "${local.tags}"
   key_name                    = "${local.ssh_deployer_key}"
-  root_device_size            = "60"
+  root_device_size            = "${var.bfs_root_size}"
 
   vpc_security_group_ids = [
     "${local.sg_map_ids["sg_mis_app_in"]}",

--- a/ec2-ndl-bfs/variables.tf
+++ b/ec2-ndl-bfs/variables.tf
@@ -11,3 +11,5 @@ variable "environment_type" {
 variable "cloudwatch_log_retention" {}
 
 variable "bfs_instance_type" {}
+
+variable "bfs_root_size" {}

--- a/ec2-ndl-bps/output.tf
+++ b/ec2-ndl-bps/output.tf
@@ -15,3 +15,39 @@ output "primary_dns" {
 output "primary_dns_ext" {
   value = "${aws_route53_record.instance_ext.fqdn}"
 }
+
+# secondary ec2
+output "secondary_instance_id" {
+  value = "${module.create-ec2-instance-002.instance_id}"
+}
+
+output "secondary_private_ip" {
+  value = "${module.create-ec2-instance-002.private_ip}"
+}
+
+# dns
+output "secondary_dns" {
+  value = "${aws_route53_record.instance_002.*.fqdn}"
+}
+
+output "secondary_dns_ext" {
+  value = "${aws_route53_record.instance_ext_002.*.fqdn}"
+}
+
+# tertiary ec2
+output "tertiary_instance_id" {
+  value = "${module.create-ec2-instance-003.instance_id}"
+}
+
+output "tertiary_private_ip" {
+  value = "${module.create-ec2-instance-003.private_ip}"
+}
+
+# dns
+output "tertiary_dns" {
+  value = "${aws_route53_record.instance_003.*.fqdn}"
+}
+
+output "tertiary_dns_ext" {
+  value = "${aws_route53_record.instance_ext_003.*.fqdn}"
+}

--- a/ec2-ndl-bps/variables.tf
+++ b/ec2-ndl-bps/variables.tf
@@ -11,3 +11,6 @@ variable "environment_type" {
 variable "cloudwatch_log_retention" {}
 
 variable "bps_instance_type" {}
+variable "bps_root_size" {}
+variable "bps_deploy_secondary" {}
+variable "bps_deploy_tertiary" {}

--- a/ec2-ndl-bws/main.tf
+++ b/ec2-ndl-bws/main.tf
@@ -179,7 +179,7 @@ module "create-ec2-instance" {
   CreateSnapshot              = false
   tags                        = "${local.tags}"
   key_name                    = "${local.ssh_deployer_key}"
-  root_device_size            = "60"
+  root_device_size            = "${var.bws_root_size}"
 
   vpc_security_group_ids = [
     "${local.sg_map_ids["sg_mis_app_in"]}",
@@ -256,7 +256,7 @@ resource "aws_instance" "instance" {
   user_data  = "${data.template_file.instance_secondary.rendered}"
 
   root_block_device {
-    volume_size = 60
+    volume_size = "${var.bws_root_size}"
   }
 
   lifecycle {

--- a/ec2-ndl-bws/variables.tf
+++ b/ec2-ndl-bws/variables.tf
@@ -53,3 +53,5 @@ variable "bws-health_check" {
 }
 
 variable "deploy_node" {}
+
+variable "bws_root_size" {}

--- a/ec2-ndl-dis/main.tf
+++ b/ec2-ndl-dis/main.tf
@@ -180,7 +180,7 @@ module "create-ec2-instance" {
   CreateSnapshot              = false
   tags                        = "${local.tags}"
   key_name                    = "${local.ssh_deployer_key}"
-  root_device_size            = "60"
+  root_device_size            = "${var.dis_root_size}"
 
   vpc_security_group_ids = [
     "${local.sg_map_ids["sg_mis_app_in"]}",

--- a/ec2-ndl-dis/variables.tf
+++ b/ec2-ndl-dis/variables.tf
@@ -11,3 +11,5 @@ variable "environment_type" {
 variable "cloudwatch_log_retention" {}
 
 variable "dis_instance_type" {}
+
+variable "dis_root_size" {}


### PR DESCRIPTION
Adds 2nd instance for BCS and BPS
Adds 3rd instance for BPS
Adds parameterised root volume size
Uses flag to ec2_no_replace_instance for 2nd and 3rd instances so they only get deployed in prod like envs when flagged in env_config file
plan tested against delius-mis-test so ensure existing env is not impacted. only change is the tag Name value gets -001 suffixed.