### PR TITLE
Bumping version of nextcloud ansible bootstrap to 1.5.2 for ALS4441

### DIFF
--- a/nextcloud/user_data/bootstrap.sh
+++ b/nextcloud/user_data/bootstrap.sh
@@ -114,7 +114,7 @@ cat << EOF > ~/requirements.yml
   src: singleplatform-eng.users
 - name: nextcloud
   src: https://github.com/ministryofjustice/hmpps-nextcloud-installer
-  version: 1.5.1
+  version: 1.5.2
 EOF
 
 wget https://raw.githubusercontent.com/ministryofjustice/hmpps-delius-ansible/master/group_vars/${bastion_inventory}.yml -O users.yml


### PR DESCRIPTION
Upgrading to 1.5.2 for nextcloud bootstrapping