### PR TITLE
Change ssm paramstore names to include app name to easily identify th…

### DIFF
--- a/modules/clamav-notify/data.tf
+++ b/modules/clamav-notify/data.tf
@@ -4,7 +4,7 @@ data "aws_region" "current" {
 
 ### Slack token URL details
 data "aws_ssm_parameter" "slack_token" {
-  name            = "/${var.name}/slack/token"
+  name            = "/mis/${var.name}/slack/token"
 }
 
 ### Lambda

--- a/monitoring/ssm.tf
+++ b/monitoring/ssm.tf
@@ -6,13 +6,13 @@ resource "random_password" "slack_webhook_url" {
 }
 
 resource "aws_ssm_parameter" "slack_token" {
-  name            = "/${var.environment_type}/slack/token"
+  name            = "/${local.mis_app_name}/${var.environment_type}/slack/token"
   type            = "SecureString"
   value           = random_password.slack_webhook_url.result
   tags            = merge(
     var.tags, 
     {
-      "Name" = "/${var.environment_type}/slack/token" 
+      "Name" = "/${local.mis_app_name}/${var.environment_type}/slack/token" 
     }
   )
 


### PR DESCRIPTION
PR to change SSM Parameter Store names to include app name ("mis") in order to identify them easier in the console. For ticket no. https://dsdmoj.atlassian.net/browse/NIT-31.