### PR TITLE
Nit 31 change iam policy

### DIFF
--- a/modules/clamav-notify/data.tf
+++ b/modules/clamav-notify/data.tf
@@ -46,7 +46,7 @@ data "aws_iam_policy_document" "lambda_policy_document" {
     statement {
         sid       = "Parameters"
         effect    = "Allow"
-        resources = ["arn:aws:ssm:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:parameter/${var.name}/slack/token"]
+        resources = ["arn:aws:ssm:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:parameter${data.aws_ssm_parameter.slack_token.name}"]
         actions   = ["ssm:GetParameter"]
     }
     statement {

--- a/monitoring/data.tf
+++ b/monitoring/data.tf
@@ -144,7 +144,7 @@ data "aws_iam_policy_document" "lambda_policy_document" {
     statement {
         sid       = "Parameters"
         effect    = "Allow"
-        resources = ["arn:aws:ssm:${var.region}:${data.aws_caller_identity.current.account_id}:parameter/${var.environment_type}/slack/token"]
+        resources = ["arn:aws:ssm:${var.region}:${data.aws_caller_identity.current.account_id}:parameter/${aws_ssm_parameter.slack_token.name}"]
         actions   = ["ssm:GetParameter"]
     }
     statement {

--- a/monitoring/data.tf
+++ b/monitoring/data.tf
@@ -144,7 +144,7 @@ data "aws_iam_policy_document" "lambda_policy_document" {
     statement {
         sid       = "Parameters"
         effect    = "Allow"
-        resources = ["arn:aws:ssm:${var.region}:${data.aws_caller_identity.current.account_id}:parameter/${aws_ssm_parameter.slack_token.name}"]
+        resources = ["arn:aws:ssm:${var.region}:${data.aws_caller_identity.current.account_id}:parameter${aws_ssm_parameter.slack_token.name}"]
         actions   = ["ssm:GetParameter"]
     }
     statement {


### PR DESCRIPTION
Updated the policy attached to the IAM role (for the lambda functions) to get ssm param store parameters. Changed code to retrieve ssm param name instead of having it hardcoded. Ticket no. https://dsdmoj.atlassian.net/browse/NIT-31