### PR TITLE
Change Slack message formatting to make alarm severity visible for users

### DIFF
--- a/modules/clamav-notify/lambda/clamav-notification.js
+++ b/modules/clamav-notify/lambda/clamav-notification.js
@@ -15,7 +15,8 @@ exports.handler = function(event, context) {
                var postData = {
                        "channel": "# " + process.env.SLACK_CHANNEL,
                        "username": "AWS SNS via Lambda :: ClamAV Notification",
-                       "text": "**************************************************************************************************"
+                       "text": icon_emoji + " AWS SNS via Lambda :: *\OK Notification\* "
+                       + "\n**************************************************************************************************"
                        + "\nInfo: "  + heading
                        + "\nDetails: "  + bodytext
                        + "\nEnvironment: "  + environment

--- a/monitoring/lambda/mis-notify-ndmis-slack.js
+++ b/monitoring/lambda/mis-notify-ndmis-slack.js
@@ -56,7 +56,8 @@ exports.handler = function(event, context) {
               var postData = {
                       "channel": "# " + process.env.SLACK_CHANNEL,
                       "username": "AWS SNS via Lambda :: Alarm Notification",
-                      "text": "**************************************************************************************************"
+                      "text": icon_emoji + " AWS SNS via Lambda :: *\Alarm Notification\* "
+                      + "\n**************************************************************************************************"
                       + "\n\nInfo: " + alarmDescription
                       + "\nAlarmState: " + newStateValue
                       +"\nMetric: " + metric
@@ -71,7 +72,8 @@ exports.handler = function(event, context) {
               var postData = {
                       "channel": "# " + process.env.SLACK_CHANNEL,
                       "username": "AWS SNS via Lambda :: OK Notification",
-                      "text": "**************************************************************************************************"
+                      "text": icon_emoji + " AWS SNS via Lambda :: *\OK Notification\* "
+                      + "\n**************************************************************************************************"
                       + "\n\nInfo: ALARM State is now OK. No Further Action Required!! The following info is for information purposes only: " + alarmDescription
                       + "\nAlarmState: " + newStateValue
                       +"\nMetric: " + metric


### PR DESCRIPTION
PR for some small formatting changes to the alert message sent to Slack through the lambda function. 
Slack apps don’t allow changing username/icon of the notifications sent to Slack so little tweaks have been done in order to enhance the visibility of the severity of the alert.
Additional change for ticket no. https://dsdmoj.atlassian.net/browse/NIT-31
