### PR TITLE
Update NextCloud MariaDB from 10.2 to 10.3

### DIFF
--- a/nextcloud/variables.tf
+++ b/nextcloud/variables.tf
@@ -67,7 +67,7 @@ variable "create_db_option_group" {
 # DB parameter group
 variable "family" {
   description = "The family of the DB parameter group"
-  default     = "mariadb10.2"
+  default     = "mariadb10.3"
 }
 
 variable "parameters" {
@@ -89,7 +89,7 @@ variable "engine" {
 
 variable "engine_version" {
   description = "The engine version to use"
-  default     = "10.2"
+  default     = "10.3"
 }
 
 # DB option group
@@ -164,7 +164,7 @@ variable "publicly_accessible" {
 
 variable "allow_major_version_upgrade" {
   description = "Indicates that major version upgrades are allowed. Changing this parameter does not result in an outage and the change is asynchronously applied as soon as possible"
-  default     = false
+  default     = true
 }
 
 variable "auto_minor_version_upgrade" {
@@ -174,7 +174,7 @@ variable "auto_minor_version_upgrade" {
 
 variable "apply_immediately" {
   description = "Specifies whether any database modifications are applied immediately, or during the next maintenance window"
-  default     = false
+  default     = true
 }
 
 variable "maintenance_window" {


### PR DESCRIPTION
Work item: https://dsdmoj.atlassian.net/browse/NIT-98

This PR is to have terraform increment the major version of the MariaDB instance from 10.2 -> 10.3.
(10.3 is the latest supported version upgrade from 10.2. Can go directly to 10.6 but NextCloud does not support that)

Terraform already applied to mis-dev successfully
[Eng-dev CodeBuild project link](https://eu-west-2.console.aws.amazon.com/codesuite/codebuild/895523100917/projects/hmpps-eng-builds-terraform-apply/build/hmpps-eng-builds-terraform-apply%3A236215c9-8902-49b8-ad61-d67c0022c4ad/?region=eu-west-2)