### PR TITLE
NIT-211 autostop-<env> tag to Phase1

### DIFF
--- a/nextcloud/maria_db.tf
+++ b/nextcloud/maria_db.tf
@@ -119,7 +119,11 @@ module "db_instance" {
   timezone           = var.timezone
   character_set_name = var.character_set_name
 
-  tags = local.tags
+  tags = merge(local.tags,
+    {
+      "autostop-${var.environment_type}" = "Phase1"
+    }
+  )
 }
 
 ###############################################


### PR DESCRIPTION
Phase1 occurs 1st when starting services, and 2nd when stopping. Original values meant that if auto start/stop was enabled in the environment, RDS databases could be shut down when apps are still running, which could result in data loss.
Setting Phase1 across all environments does not mean that databases will be shut down over night. RDS DB schedules are disabled at the lambda level