### PR TITLE
Add permission for cross-account copy of DFI reports

### DIFF
--- a/ec2-ndl-dfi/s3-bucket.tf
+++ b/ec2-ndl-dfi/s3-bucket.tf
@@ -2,24 +2,17 @@ locals {
   bucket_name = "${var.region}-${var.environment_name}-dfi-extracts"
 }
 
-data "aws_ssm_parameter" "cross_account_sync_id" {
-  name = "dfi-cross-account-sync-development"
-}
-
-data "aws_ssm_parameter" "sync_user" {
-  name = "github-dfi-cross-account-sync-user"
-}
-
-
 data "template_file" "dfi" {
   template = file("./templates/s3_policy.tpl")
 
   vars = {
-    dfi_account      = var.aws_account_ids["cloud-platform"]
-    region           = var.region
-    environment_name = var.environment_name
-    account_id       = data.aws_ssm_parameter.cross_account_sync_id.value
-    sync_user        = data.aws_ssm_parameter.sync_user.value
+    dfi_account              = var.aws_account_ids["cloud-platform"]
+    region                   = var.region
+    environment_name         = var.environment_name
+    sync_user                = aws_ssm_parameter.sync_user.value
+    account_id_development   = aws_ssm_parameter.cross_account_sync_id_development.value
+    account_id_preproduction = aws_ssm_parameter.cross_account_sync_id_preproduction.value
+    account_id_production    = aws_ssm_parameter.cross_account_sync_id_production.value
   }
 }
 

--- a/ec2-ndl-dfi/s3-bucket.tf
+++ b/ec2-ndl-dfi/s3-bucket.tf
@@ -2,14 +2,24 @@ locals {
   bucket_name = "${var.region}-${var.environment_name}-dfi-extracts"
 }
 
+data "aws_ssm_parameter" "cross_account_sync_id" {
+  name = "dfi-cross-account-sync-development"
+}
+
+data "aws_ssm_parameter" "sync_user" {
+  name = "github-dfi-cross-account-sync-user"
+}
+
 
 data "template_file" "dfi" {
-  template = "${file("./templates/s3_policy.tpl")}"
+  template = file("./templates/s3_policy.tpl")
 
   vars = {
     dfi_account      = var.aws_account_ids["cloud-platform"]
     region           = var.region
     environment_name = var.environment_name
+    account_id       = data.aws_ssm_parameter.cross_account_sync_id.value
+    sync_user        = data.aws_ssm_parameter.sync_user.value
   }
 }
 
@@ -23,7 +33,7 @@ resource "aws_s3_bucket_policy" "dfi" {
 resource "aws_s3_bucket" "dfi" {
   bucket = local.bucket_name
 
-  acl    = "private"
+  acl = "private"
 
   versioning {
     enabled = true
@@ -57,17 +67,17 @@ resource "aws_s3_bucket" "dfi" {
 
 #Create folders for dfi
 resource "aws_s3_bucket_object" "dfi" {
-    for_each = toset(["dfi"])
-    bucket   = aws_s3_bucket.dfi.id
-    acl      = "private"
-    key      = format("/dfinterventions/%s/", each.key)
+  for_each = toset(["dfi"])
+  bucket   = aws_s3_bucket.dfi.id
+  acl      = "private"
+  key      = format("/dfinterventions/%s/", each.key)
 }
 
 #Create folder for infected files
 resource "aws_s3_bucket_object" "infected" {
-    bucket   = aws_s3_bucket.dfi.id
-    acl      = "private"
-    key      = "/infected/"
+  bucket = aws_s3_bucket.dfi.id
+  acl    = "private"
+  key    = "/infected/"
 }
 
 #resource "aws_s3_bucket_ownership_controls" "dfi" {

--- a/ec2-ndl-dfi/s3-bucket.tf
+++ b/ec2-ndl-dfi/s3-bucket.tf
@@ -6,13 +6,11 @@ data "template_file" "dfi" {
   template = file("./templates/s3_policy.tpl")
 
   vars = {
-    dfi_account              = var.aws_account_ids["cloud-platform"]
-    region                   = var.region
-    environment_name         = var.environment_name
-    sync_user                = aws_ssm_parameter.sync_user.value
-    account_id_development   = aws_ssm_parameter.cross_account_sync_id_development.value
-    account_id_preproduction = aws_ssm_parameter.cross_account_sync_id_preproduction.value
-    account_id_production    = aws_ssm_parameter.cross_account_sync_id_production.value
+    dfi_account      = var.aws_account_ids["cloud-platform"]
+    region           = var.region
+    environment_name = var.environment_name
+    sync_user        = aws_ssm_parameter.sync_user.value
+    account_id       = aws_ssm_parameter.cross_account_sync_id.value
   }
 }
 

--- a/ec2-ndl-dfi/ssm-parameters.tf
+++ b/ec2-ndl-dfi/ssm-parameters.tf
@@ -10,7 +10,7 @@ resource "aws_ssm_parameter" "cross_account_sync_id" {
     local.tags,
     {
       "Name"        = "dfi-cross-account-sync"
-      "Environment" = "development"
+      "Environment" = var.environment_name
     }
   )
 
@@ -22,7 +22,7 @@ resource "aws_ssm_parameter" "cross_account_sync_id" {
 resource "aws_ssm_parameter" "sync_user" {
   name  = "modernisation-platform-oidc-cicd"
   type  = "String"
-  value = "PLACEHOLDER" # Update this manually after creation
+  value = "modernisation-platform-oidc-cicd"
 
   description = "Username for DFI cross-account sync operations"
 

--- a/ec2-ndl-dfi/ssm-parameters.tf
+++ b/ec2-ndl-dfi/ssm-parameters.tf
@@ -1,56 +1,16 @@
 # SSM Parameters for cross-account sync
-resource "aws_ssm_parameter" "cross_account_sync_id_development" {
-  name  = "dfi-cross-account-sync-development"
+resource "aws_ssm_parameter" "cross_account_sync_id" {
+  name  = "dfi-cross-account-sync-id"
   type  = "String"
   value = "PLACEHOLDER" # Update this manually after creation
 
-  description = "AWS Account ID for DFI cross-account sync - Development environment"
+  description = "AWS Account ID for DFI cross-account sync"
 
   tags = merge(
     local.tags,
     {
-      "Name"        = "dfi-cross-account-sync-development"
+      "Name"        = "dfi-cross-account-sync"
       "Environment" = "development"
-    }
-  )
-
-  lifecycle {
-    ignore_changes = [value]
-  }
-}
-
-resource "aws_ssm_parameter" "cross_account_sync_id_preproduction" {
-  name  = "dfi-cross-account-sync-preproduction"
-  type  = "String"
-  value = "PLACEHOLDER" # Update this manually after creation
-
-  description = "AWS Account ID for DFI cross-account sync - Pre-production environment"
-
-  tags = merge(
-    local.tags,
-    {
-      "Name"        = "dfi-cross-account-sync-preproduction"
-      "Environment" = "preproduction"
-    }
-  )
-
-  lifecycle {
-    ignore_changes = [value]
-  }
-}
-
-resource "aws_ssm_parameter" "cross_account_sync_id_production" {
-  name  = "dfi-cross-account-sync-production"
-  type  = "String"
-  value = "PLACEHOLDER" # Update this manually after creation
-
-  description = "AWS Account ID for DFI cross-account sync - Production environment"
-
-  tags = merge(
-    local.tags,
-    {
-      "Name"        = "dfi-cross-account-sync-production"
-      "Environment" = "production"
     }
   )
 

--- a/ec2-ndl-dfi/ssm-parameters.tf
+++ b/ec2-ndl-dfi/ssm-parameters.tf
@@ -1,0 +1,79 @@
+# SSM Parameters for cross-account sync
+resource "aws_ssm_parameter" "cross_account_sync_id_development" {
+  name  = "dfi-cross-account-sync-development"
+  type  = "String"
+  value = "PLACEHOLDER" # Update this manually after creation
+
+  description = "AWS Account ID for DFI cross-account sync - Development environment"
+
+  tags = merge(
+    local.tags,
+    {
+      "Name"        = "dfi-cross-account-sync-development"
+      "Environment" = "development"
+    }
+  )
+
+  lifecycle {
+    ignore_changes = [value]
+  }
+}
+
+resource "aws_ssm_parameter" "cross_account_sync_id_preproduction" {
+  name  = "dfi-cross-account-sync-preproduction"
+  type  = "String"
+  value = "PLACEHOLDER" # Update this manually after creation
+
+  description = "AWS Account ID for DFI cross-account sync - Pre-production environment"
+
+  tags = merge(
+    local.tags,
+    {
+      "Name"        = "dfi-cross-account-sync-preproduction"
+      "Environment" = "preproduction"
+    }
+  )
+
+  lifecycle {
+    ignore_changes = [value]
+  }
+}
+
+resource "aws_ssm_parameter" "cross_account_sync_id_production" {
+  name  = "dfi-cross-account-sync-production"
+  type  = "String"
+  value = "PLACEHOLDER" # Update this manually after creation
+
+  description = "AWS Account ID for DFI cross-account sync - Production environment"
+
+  tags = merge(
+    local.tags,
+    {
+      "Name"        = "dfi-cross-account-sync-production"
+      "Environment" = "production"
+    }
+  )
+
+  lifecycle {
+    ignore_changes = [value]
+  }
+}
+
+resource "aws_ssm_parameter" "sync_user" {
+  name  = "github-dfi-cross-account-sync-user"
+  type  = "String"
+  value = "PLACEHOLDER" # Update this manually after creation
+
+  description = "Username for DFI cross-account sync operations"
+
+  tags = merge(
+    local.tags,
+    {
+      "Name" = "github-dfi-cross-account-sync-user"
+    }
+  )
+
+  lifecycle {
+    ignore_changes = [value]
+  }
+}

--- a/ec2-ndl-dfi/ssm-parameters.tf
+++ b/ec2-ndl-dfi/ssm-parameters.tf
@@ -60,7 +60,7 @@ resource "aws_ssm_parameter" "cross_account_sync_id_production" {
 }
 
 resource "aws_ssm_parameter" "sync_user" {
-  name  = "github-dfi-cross-account-sync-user"
+  name  = "modernisation-platform-oidc-cicd"
   type  = "String"
   value = "PLACEHOLDER" # Update this manually after creation
 
@@ -69,7 +69,7 @@ resource "aws_ssm_parameter" "sync_user" {
   tags = merge(
     local.tags,
     {
-      "Name" = "github-dfi-cross-account-sync-user"
+      "Name" = "modernisation-platform-oidc-cicd"
     }
   )
 

--- a/ec2-ndl-dfi/templates/s3_policy.tpl
+++ b/ec2-ndl-dfi/templates/s3_policy.tpl
@@ -63,7 +63,11 @@
       "Sid": "AllowCrossAccountGet",
       "Effect": "Allow",
       "Principal": {
-        "AWS": "arn:aws:iam::${account_id}:user/${sync_user}"
+        "AWS": [
+          "arn:aws:iam::${account_id_development}:user/${sync_user}",
+          "arn:aws:iam::${account_id_preproduction}:user/${sync_user}",
+          "arn:aws:iam::${account_id_production}:user/${sync_user}"
+        ]
       },
       "Action": [
         "s3:GetObject",

--- a/ec2-ndl-dfi/templates/s3_policy.tpl
+++ b/ec2-ndl-dfi/templates/s3_policy.tpl
@@ -64,9 +64,7 @@
       "Effect": "Allow",
       "Principal": {
         "AWS": [
-          "arn:aws:iam::${account_id_development}:user/${sync_user}",
-          "arn:aws:iam::${account_id_preproduction}:user/${sync_user}",
-          "arn:aws:iam::${account_id_production}:user/${sync_user}"
+          "arn:aws:iam::${account_id}:user/${sync_user}"
         ]
       },
       "Action": [

--- a/ec2-ndl-dfi/templates/s3_policy.tpl
+++ b/ec2-ndl-dfi/templates/s3_policy.tpl
@@ -1,37 +1,78 @@
 {
-  "Version":"2012-10-17",
-  "Statement":[
+  "Version": "2012-10-17",
+  "Statement": [
     {
-      "Sid":"DfiS3PutPolicy",
-      "Effect":"Allow",
-    "Principal": {"AWS": "arn:aws:iam::${dfi_account}:root"},
-      "Action":["s3:PutObject","s3:PutObjectAcl"],
-      "Resource": [
-          "arn:aws:s3:::${region}-${environment_name}-dfi-extracts/dfinterventions/dfi/*",
-          "arn:aws:s3:::${region}-${environment_name}-dfi-extracts"
+      "Sid": "DfiS3PutPolicy",
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": "arn:aws:iam::${dfi_account}:root"
+      },
+      "Action": [
+        "s3:PutObject",
+        "s3:PutObjectAcl"
       ],
-      "Condition":{"StringEquals":{"s3:x-amz-acl":["bucket-owner-full-control"]}}
+      "Resource": [
+        "arn:aws:s3:::${region}-${environment_name}-dfi-extracts/dfinterventions/dfi/*",
+        "arn:aws:s3:::${region}-${environment_name}-dfi-extracts"
+      ],
+      "Condition": {
+        "StringEquals": {
+          "s3:x-amz-acl": [
+            "bucket-owner-full-control"
+          ]
+        }
+      }
     },
     {
-      "Sid":"DfiS3ListPolicy",
-      "Effect":"Allow",
-    "Principal": {"AWS": "arn:aws:iam::${dfi_account}:root"},
-      "Action":["s3:List*","s3:DeleteObject*","s3:GetObject*","s3:GetBucketLocation"],
+      "Sid": "DfiS3ListPolicy",
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": "arn:aws:iam::${dfi_account}:root"
+      },
+      "Action": [
+        "s3:List*",
+        "s3:DeleteObject*",
+        "s3:GetObject*",
+        "s3:GetBucketLocation"
+      ],
       "Resource": [
-          "arn:aws:s3:::${region}-${environment_name}-dfi-extracts/dfinterventions/dfi/*",
-          "arn:aws:s3:::${region}-${environment_name}-dfi-extracts"
+        "arn:aws:s3:::${region}-${environment_name}-dfi-extracts/dfinterventions/dfi/*",
+        "arn:aws:s3:::${region}-${environment_name}-dfi-extracts"
       ]
     },
     {
-      "Sid":"DfiS3GetPolicy",
-      "Effect":"Deny",
-    "Principal": "*",
-      "Action":["s3:GetObject"],
-      "Resource": [
-          "arn:aws:s3:::${region}-${environment_name}-dfi-extracts/*",
-          "arn:aws:s3:::${region}-${environment_name}-dfi-extracts"
+      "Sid": "DfiS3GetPolicy",
+      "Effect": "Deny",
+      "Principal": "*",
+      "Action": [
+        "s3:GetObject"
       ],
-      "Condition":{"StringEquals":{"s3:ExistingObjectTag/av-status":["infected"]}}
+      "Resource": [
+        "arn:aws:s3:::${region}-${environment_name}-dfi-extracts/*",
+        "arn:aws:s3:::${region}-${environment_name}-dfi-extracts"
+      ],
+      "Condition": {
+        "StringEquals": {
+          "s3:ExistingObjectTag/av-status": [
+            "infected"
+          ]
+        }
+      }
+    },
+    {
+      "Sid": "AllowCrossAccountGet",
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": "arn:aws:iam::${account_id}:user/${sync_user}"
+      },
+      "Action": [
+        "s3:GetObject",
+        "s3:ListBucket"
+      ],
+      "Resource": [
+        "arn:aws:s3:::${region}-${environment_name}-dfi-extracts/dfinterventions/dfi/*",
+        "arn:aws:s3:::${region}-${environment_name}-dfi-extracts"
+      ]
     }
   ]
 }

--- a/ec2-ndl-dfi/templates/s3_policy.tpl
+++ b/ec2-ndl-dfi/templates/s3_policy.tpl
@@ -63,9 +63,7 @@
       "Sid": "AllowCrossAccountGet",
       "Effect": "Allow",
       "Principal": {
-        "AWS": [
-          "arn:aws:iam::${account_id}:user/${sync_user}"
-        ]
+        "AWS": "arn:aws:iam::${account_id}:user/${sync_user}"
       },
       "Action": [
         "s3:GetObject",


### PR DESCRIPTION
As part of the migration of DFI/Mis reporting to AWS modernisation platform we need to copy the DFI reports from the existing S3 bucket to the modernisation platform delius-mis/development/preproduction/production environments.

- added 4 x ssm parameters to extend the s3_policy.tpl file
- added AllowCrossAccountGet policy to s3_policy.tpl 
  - this enables a GitHub action pipeline to run from the delius-mis AWS account(s) and use aws s3 sync to copy the files
  - proposed pipeline, needs PR review, included here to illustrate the idea
    - https://github.com/ministryofjustice/dso-modernisation-platform-automation/pull/164
  
NOTE: I am NOT familiar with how this terraform is validated or deployed. Is there any way to see a PLAN output first so these changes/resources can be checked first? Will the ssm-parameters be deployed into the correct accounts for the template builder to be able to get them from the right account/location?