### PR TITLE
add s3 policy for datasync role retrieval

### DIFF
--- a/ec2-ndl-dfi/templates/s3_policy.tpl
+++ b/ec2-ndl-dfi/templates/s3_policy.tpl
@@ -1,37 +1,87 @@
 {
-  "Version":"2012-10-17",
-  "Statement":[
+  "Version": "2012-10-17",
+  "Statement": [
     {
-      "Sid":"DfiS3PutPolicy",
-      "Effect":"Allow",
-    "Principal": {"AWS": "arn:aws:iam::${dfi_account}:root"},
-      "Action":["s3:PutObject","s3:PutObjectAcl"],
-      "Resource": [
-          "arn:aws:s3:::${region}-${environment_name}-dfi-extracts/dfinterventions/dfi/*",
-          "arn:aws:s3:::${region}-${environment_name}-dfi-extracts"
+      "Sid": "DfiS3PutPolicy",
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": "arn:aws:iam::${dfi_account}:root"
+      },
+      "Action": [
+        "s3:PutObject",
+        "s3:PutObjectAcl"
       ],
-      "Condition":{"StringEquals":{"s3:x-amz-acl":["bucket-owner-full-control"]}}
+      "Resource": [
+        "arn:aws:s3:::${region}-${environment_name}-dfi-extracts/dfinterventions/dfi/*",
+        "arn:aws:s3:::${region}-${environment_name}-dfi-extracts"
+      ],
+      "Condition": {
+        "StringEquals": {
+          "s3:x-amz-acl": [
+            "bucket-owner-full-control"
+          ]
+        }
+      }
     },
     {
-      "Sid":"DfiS3ListPolicy",
-      "Effect":"Allow",
-    "Principal": {"AWS": "arn:aws:iam::${dfi_account}:root"},
-      "Action":["s3:List*","s3:DeleteObject*","s3:GetObject*","s3:GetBucketLocation"],
+      "Sid": "DfiS3ListPolicy",
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": "arn:aws:iam::${dfi_account}:root"
+      },
+      "Action": [
+        "s3:List*",
+        "s3:DeleteObject*",
+        "s3:GetObject*",
+        "s3:GetBucketLocation"
+      ],
       "Resource": [
-          "arn:aws:s3:::${region}-${environment_name}-dfi-extracts/dfinterventions/dfi/*",
-          "arn:aws:s3:::${region}-${environment_name}-dfi-extracts"
+        "arn:aws:s3:::${region}-${environment_name}-dfi-extracts/dfinterventions/dfi/*",
+        "arn:aws:s3:::${region}-${environment_name}-dfi-extracts"
       ]
     },
     {
-      "Sid":"DfiS3GetPolicy",
-      "Effect":"Deny",
-    "Principal": "*",
-      "Action":["s3:GetObject"],
-      "Resource": [
-          "arn:aws:s3:::${region}-${environment_name}-dfi-extracts/*",
-          "arn:aws:s3:::${region}-${environment_name}-dfi-extracts"
+      "Sid": "DataSyncReadPolicy",
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": "arn:aws:iam::*:role/delius-mis-*-datasync-s3-role"
+      },
+      "Action": [
+        "s3:GetBucketLocation",
+        "s3:ListBucket",
+        "s3:ListBucketMultipartUploads",
+        "s3:ListBucketVersions",
+        "s3:GetBucketVersioning",
+        "s3:GetObject",
+        "s3:GetObjectTagging",
+        "s3:GetObjectVersion",
+        "s3:GetObjectVersionTagging",
+        "s3:GetObjectAcl",
+        "s3:GetObjectVersionAcl"
       ],
-      "Condition":{"StringEquals":{"s3:ExistingObjectTag/av-status":["infected"]}}
+      "Resource": [
+        "arn:aws:s3:::${region}-${environment_name}-dfi-extracts",
+        "arn:aws:s3:::${region}-${environment_name}-dfi-extracts/*"
+      ]
+    },
+    {
+      "Sid": "DfiS3GetPolicy",
+      "Effect": "Deny",
+      "Principal": "*",
+      "Action": [
+        "s3:GetObject"
+      ],
+      "Resource": [
+        "arn:aws:s3:::${region}-${environment_name}-dfi-extracts/*",
+        "arn:aws:s3:::${region}-${environment_name}-dfi-extracts"
+      ],
+      "Condition": {
+        "StringEquals": {
+          "s3:ExistingObjectTag/av-status": [
+            "infected"
+          ]
+        }
+      }
     }
   ]
 }


### PR DESCRIPTION
- expand s3 policy to allow datasync role from delius-mis accounts to get bucket content