### PR TITLE
remove un-created arns

### DIFF
--- a/ec2-ndl-dfi/templates/s3_policy.tpl
+++ b/ec2-ndl-dfi/templates/s3_policy.tpl
@@ -45,10 +45,7 @@
       "Effect": "Allow",
       "Principal": {
         "AWS": [
-          "arn:aws:iam::891377175249:role/delius-mis-dev-datasync-s3-role",
-          "arn:aws:iam::471112751565:role/delius-mis-stage-datasync-s3-role",
-          "arn:aws:iam::471112751565:role/delius-mis-preprod-datasync-s3-role",
-          "arn:aws:iam::590183722357:role/delius-mis-prod-datasync-s3-role"
+          "arn:aws:iam::891377175249:role/delius-mis-dev-datasync-s3-role"
         ]
       },
       "Action": [


### PR DESCRIPTION
can't reference un-created arns

since other branch in modernisation-platform-environments hasn't succeeded the connection check yet just create this (development) one and then re-run the mp platform which will confirm that from a permissions pov at least this will all work