### PR TITLE
TM-1912: allow connectivity to modplatform dc and fsx

### DIFF
--- a/common/main.tf
+++ b/common/main.tf
@@ -50,7 +50,7 @@ locals {
   s3_lb_policy_file                   = "../policies/s3_alb_policy.json"
   environment                         = var.environment_type
   legacy_environment_name             = var.legacy_environment_name
-  modernisation_platform_hmpp_dc_cidr = contains(["stage", "pre-prod", "prod"], var.environment_identifier) ? "10.27.136.0/21" : "10.20.96.0/19"
+  modernisation_platform_hmpp_dc_cidr = var.modernisation_platform_hmpp_dc_cidr
 
   tags = merge(
     data.terraform_remote_state.vpc.outputs.tags,

--- a/common/main.tf
+++ b/common/main.tf
@@ -50,7 +50,7 @@ locals {
   s3_lb_policy_file                   = "../policies/s3_alb_policy.json"
   environment                         = var.environment_type
   legacy_environment_name             = var.legacy_environment_name
-  modernisation_platform_hmpp_dc_cidr = var.modernisation_platform_hmpp_dc_cidr
+  modernisation_platform_hmpp_dc_cidr = contains(["stage", "pre-prod", "prod"], var.environment_identifier) ? "10.27.136.0/21" : "10.20.96.0/19"
 
   tags = merge(
     data.terraform_remote_state.vpc.outputs.tags,

--- a/common/main.tf
+++ b/common/main.tf
@@ -32,24 +32,26 @@ data "terraform_remote_state" "vpc" {
 ####################################################
 
 locals {
-  vpc_id                       = data.terraform_remote_state.vpc.outputs.vpc_id
-  cidr_block                   = data.terraform_remote_state.vpc.outputs.vpc_cidr_block
-  allowed_cidr_block           = [data.terraform_remote_state.vpc.outputs.vpc_cidr_block]
-  bastion_cidr                 = data.terraform_remote_state.vpc.outputs.bastion_vpc_public_cidr
-  internal_domain              = data.terraform_remote_state.vpc.outputs.private_zone_name
-  private_zone_id              = data.terraform_remote_state.vpc.outputs.private_zone_id
-  external_domain              = data.terraform_remote_state.vpc.outputs.public_zone_name
-  public_zone_id               = data.terraform_remote_state.vpc.outputs.public_zone_id
-  common_name                  = "${var.environment_identifier}-${var.mis_app_name}"
-  lb_account_id                = var.lb_account_id
-  region                       = var.region
-  role_arn                     = var.role_arn
-  environment_identifier       = var.environment_identifier
-  short_environment_identifier = var.short_environment_identifier
-  remote_state_bucket_name     = var.remote_state_bucket_name
-  s3_lb_policy_file            = "../policies/s3_alb_policy.json"
-  environment                  = var.environment_type
-  legacy_environment_name      = var.legacy_environment_name
+  vpc_id                              = data.terraform_remote_state.vpc.outputs.vpc_id
+  cidr_block                          = data.terraform_remote_state.vpc.outputs.vpc_cidr_block
+  allowed_cidr_block                  = [data.terraform_remote_state.vpc.outputs.vpc_cidr_block]
+  bastion_cidr                        = data.terraform_remote_state.vpc.outputs.bastion_vpc_public_cidr
+  internal_domain                     = data.terraform_remote_state.vpc.outputs.private_zone_name
+  private_zone_id                     = data.terraform_remote_state.vpc.outputs.private_zone_id
+  external_domain                     = data.terraform_remote_state.vpc.outputs.public_zone_name
+  public_zone_id                      = data.terraform_remote_state.vpc.outputs.public_zone_id
+  common_name                         = "${var.environment_identifier}-${var.mis_app_name}"
+  lb_account_id                       = var.lb_account_id
+  region                              = var.region
+  role_arn                            = var.role_arn
+  environment_identifier              = var.environment_identifier
+  short_environment_identifier        = var.short_environment_identifier
+  remote_state_bucket_name            = var.remote_state_bucket_name
+  s3_lb_policy_file                   = "../policies/s3_alb_policy.json"
+  environment                         = var.environment_type
+  legacy_environment_name             = var.legacy_environment_name
+  modernisation_platform_hmpp_dc_cidr = var.modernisation_platform_hmpp_dc_cidr
+
   tags = merge(
     data.terraform_remote_state.vpc.outputs.tags,
     {
@@ -109,20 +111,21 @@ locals {
 # Common
 ####################################################
 module "common" {
-  source                       = "../modules/common"
-  cidr_block                   = local.cidr_block
-  common_name                  = local.common_name
-  environment                  = local.environment
-  environment_identifier       = local.environment_identifier
-  internal_domain              = local.internal_domain
-  lb_account_id                = local.lb_account_id
-  private_zone_id              = local.private_zone_id
-  s3_lb_policy_file            = local.s3_lb_policy_file
-  short_environment_identifier = local.short_environment_identifier
-  tags                         = local.tags
-  vpc_id                       = local.vpc_id
-  region                       = local.region
-  password_length              = local.password_length
+  source                              = "../modules/common"
+  cidr_block                          = local.cidr_block
+  common_name                         = local.common_name
+  environment                         = local.environment
+  environment_identifier              = local.environment_identifier
+  internal_domain                     = local.internal_domain
+  lb_account_id                       = local.lb_account_id
+  private_zone_id                     = local.private_zone_id
+  s3_lb_policy_file                   = local.s3_lb_policy_file
+  short_environment_identifier        = local.short_environment_identifier
+  tags                                = local.tags
+  vpc_id                              = local.vpc_id
+  region                              = local.region
+  password_length                     = local.password_length
+  modernisation_platform_hmpp_dc_cidr = local.modernisation_platform_hmpp_dc_cidr
 }
 
 ####################################################

--- a/common/variables.tf
+++ b/common/variables.tf
@@ -44,8 +44,3 @@ variable "legacy_environment_name" {
   default     = "100"
   description = "legacy environment name"
 }
-
-variable "modernisation_platform_hmpp_dc_cidr" {
-  type    = string
-  default = null
-}

--- a/common/variables.tf
+++ b/common/variables.tf
@@ -44,3 +44,9 @@ variable "legacy_environment_name" {
   default     = "100"
   description = "legacy environment name"
 }
+
+variable "modernisation_platform_hmpp_dc_cidr" {
+  type        = string
+  default     = null
+  description = "cidr where HMPP DCs and FSX sit for mounting NART file share"
+}

--- a/common/variables.tf
+++ b/common/variables.tf
@@ -45,3 +45,7 @@ variable "legacy_environment_name" {
   description = "legacy environment name"
 }
 
+variable "modernisation_platform_hmpp_dc_cidr" {
+  type    = string
+  default = null
+}

--- a/modules/common/main.tf
+++ b/modules/common/main.tf
@@ -60,6 +60,30 @@ resource "aws_security_group_rule" "https" {
   description       = "${local.common_name}-https"
 }
 
+resource "aws_security_group_rule" "modernisation_platform_hmpp_dc_udp" {
+  count = modernisation_platform_hmpp_dc_cidr != null ? 1 : 0
+
+  security_group_id = aws_security_group.vpc-sg-outbound.id
+  type              = "egress"
+  from_port         = "0"
+  to_port           = "65535"
+  protocol          = "udp"
+  cidr_blocks       = [var.modernisation_platform_hmpp_dc_cidr]
+  description       = "${local.common_name}-modernisation-platform-hmpp-dc-udp"
+}
+
+resource "aws_security_group_rule" "modernisation_platform_hmpp_dc_tdp" {
+  count = modernisation_platform_hmpp_dc_cidr != null ? 1 : 0
+
+  security_group_id = aws_security_group.vpc-sg-outbound.id
+  type              = "egress"
+  from_port         = "0"
+  to_port           = "65535"
+  protocol          = "tcp"
+  cidr_blocks       = [var.modernisation_platform_hmpp_dc_cidr]
+  description       = "${local.common_name}-modernisation-platform-hmpp-dc-tdp"
+}
+
 # #-------------------------------------------
 # ### S3 bucket for config
 # #--------------------------------------------

--- a/modules/common/main.tf
+++ b/modules/common/main.tf
@@ -61,7 +61,7 @@ resource "aws_security_group_rule" "https" {
 }
 
 resource "aws_security_group_rule" "modernisation_platform_hmpp_dc_udp" {
-  count = modernisation_platform_hmpp_dc_cidr != null ? 1 : 0
+  count = var.modernisation_platform_hmpp_dc_cidr != null ? 1 : 0
 
   security_group_id = aws_security_group.vpc-sg-outbound.id
   type              = "egress"
@@ -73,7 +73,7 @@ resource "aws_security_group_rule" "modernisation_platform_hmpp_dc_udp" {
 }
 
 resource "aws_security_group_rule" "modernisation_platform_hmpp_dc_tdp" {
-  count = modernisation_platform_hmpp_dc_cidr != null ? 1 : 0
+  count = var.modernisation_platform_hmpp_dc_cidr != null ? 1 : 0
 
   security_group_id = aws_security_group.vpc-sg-outbound.id
   type              = "egress"

--- a/modules/common/variables.tf
+++ b/modules/common/variables.tf
@@ -43,3 +43,7 @@ variable "password_length" {
   default = "18"
 }
 
+variable "modernisation_platform_hmpp_dc_cidr" {
+  type    = string
+  default = null
+}


### PR DESCRIPTION
Allow all outbound traffic to HMPP domain controllers and file share.

This will allow NART to mount the existing NART file share which they use to promote content between environments. Allowing all egress ports for simplicity - the individual inbound ports are locked down on the domain controller ingress side.