### PR TITLE
TM-1912: delius-mis: add route53 forwarder to hmpp domain

### DIFF
--- a/common/main.tf
+++ b/common/main.tf
@@ -32,25 +32,27 @@ data "terraform_remote_state" "vpc" {
 ####################################################
 
 locals {
-  vpc_id                              = data.terraform_remote_state.vpc.outputs.vpc_id
-  cidr_block                          = data.terraform_remote_state.vpc.outputs.vpc_cidr_block
-  allowed_cidr_block                  = [data.terraform_remote_state.vpc.outputs.vpc_cidr_block]
-  bastion_cidr                        = data.terraform_remote_state.vpc.outputs.bastion_vpc_public_cidr
-  internal_domain                     = data.terraform_remote_state.vpc.outputs.private_zone_name
-  private_zone_id                     = data.terraform_remote_state.vpc.outputs.private_zone_id
-  external_domain                     = data.terraform_remote_state.vpc.outputs.public_zone_name
-  public_zone_id                      = data.terraform_remote_state.vpc.outputs.public_zone_id
-  common_name                         = "${var.environment_identifier}-${var.mis_app_name}"
-  lb_account_id                       = var.lb_account_id
-  region                              = var.region
-  role_arn                            = var.role_arn
-  environment_identifier              = var.environment_identifier
-  short_environment_identifier        = var.short_environment_identifier
-  remote_state_bucket_name            = var.remote_state_bucket_name
-  s3_lb_policy_file                   = "../policies/s3_alb_policy.json"
-  environment                         = var.environment_type
-  legacy_environment_name             = var.legacy_environment_name
-  modernisation_platform_hmpp_dc_cidr = var.modernisation_platform_hmpp_dc_cidr
+  vpc_id                                  = data.terraform_remote_state.vpc.outputs.vpc_id
+  cidr_block                              = data.terraform_remote_state.vpc.outputs.vpc_cidr_block
+  allowed_cidr_block                      = [data.terraform_remote_state.vpc.outputs.vpc_cidr_block]
+  bastion_cidr                            = data.terraform_remote_state.vpc.outputs.bastion_vpc_public_cidr
+  internal_domain                         = data.terraform_remote_state.vpc.outputs.private_zone_name
+  private_zone_id                         = data.terraform_remote_state.vpc.outputs.private_zone_id
+  external_domain                         = data.terraform_remote_state.vpc.outputs.public_zone_name
+  public_zone_id                          = data.terraform_remote_state.vpc.outputs.public_zone_id
+  common_name                             = "${var.environment_identifier}-${var.mis_app_name}"
+  lb_account_id                           = var.lb_account_id
+  region                                  = var.region
+  role_arn                                = var.role_arn
+  environment_identifier                  = var.environment_identifier
+  short_environment_identifier            = var.short_environment_identifier
+  remote_state_bucket_name                = var.remote_state_bucket_name
+  s3_lb_policy_file                       = "../policies/s3_alb_policy.json"
+  environment                             = var.environment_type
+  legacy_environment_name                 = var.legacy_environment_name
+  modernisation_platform_hmpp_dc_cidr     = var.modernisation_platform_hmpp_dc_cidr
+  modernisation_platform_hmpp_dc_ips      = var.modernisation_platform_hmpp_dc_ips
+  modernisation_platform_hmpp_domain_name = var.modernisation_platform_hmpp_domain_name
 
   tags = merge(
     data.terraform_remote_state.vpc.outputs.tags,
@@ -111,21 +113,24 @@ locals {
 # Common
 ####################################################
 module "common" {
-  source                              = "../modules/common"
-  cidr_block                          = local.cidr_block
-  common_name                         = local.common_name
-  environment                         = local.environment
-  environment_identifier              = local.environment_identifier
-  internal_domain                     = local.internal_domain
-  lb_account_id                       = local.lb_account_id
-  private_zone_id                     = local.private_zone_id
-  s3_lb_policy_file                   = local.s3_lb_policy_file
-  short_environment_identifier        = local.short_environment_identifier
-  tags                                = local.tags
-  vpc_id                              = local.vpc_id
-  region                              = local.region
-  password_length                     = local.password_length
-  modernisation_platform_hmpp_dc_cidr = local.modernisation_platform_hmpp_dc_cidr
+  source                                  = "../modules/common"
+  cidr_block                              = local.cidr_block
+  common_name                             = local.common_name
+  environment                             = local.environment
+  environment_identifier                  = local.environment_identifier
+  internal_domain                         = local.internal_domain
+  lb_account_id                           = local.lb_account_id
+  private_subnet_map                      = local.private_subnet_map
+  private_zone_id                         = local.private_zone_id
+  s3_lb_policy_file                       = local.s3_lb_policy_file
+  short_environment_identifier            = local.short_environment_identifier
+  tags                                    = local.tags
+  vpc_id                                  = local.vpc_id
+  region                                  = local.region
+  password_length                         = local.password_length
+  modernisation_platform_hmpp_dc_cidr     = local.modernisation_platform_hmpp_dc_cidr
+  modernisation_platform_hmpp_dc_ips      = local.modernisation_platform_hmpp_dc_ips
+  modernisation_platform_hmpp_domain_name = local.modernisation_platform_hmpp_domain_name
 }
 
 ####################################################

--- a/common/variables.tf
+++ b/common/variables.tf
@@ -50,3 +50,13 @@ variable "modernisation_platform_hmpp_dc_cidr" {
   default     = null
   description = "cidr where HMPP DCs and FSX sit for mounting NART file share"
 }
+
+variable "modernisation_platform_hmpp_dc_ips" {
+  type    = list(string)
+  default = null
+}
+
+variable "modernisation_platform_hmpp_domain_name" {
+  type    = string
+  default = null
+}

--- a/modules/common/route53.tf
+++ b/modules/common/route53.tf
@@ -1,0 +1,83 @@
+resource "aws_security_group" "hmpp_route53_resolver" {
+  count = var.modernisation_platform_hmpp_domain_name != null ? 1 : 0
+
+  name        = "hmpp-route53-resolver-sg"
+  description = "Route53 resolver security group for ForwardToHMPPDomainTF"
+  vpc_id      = local.vpc_id
+
+  tags = merge(local.tags, {
+    Name = "hmpp-route53-resolver-sg"
+  })
+}
+
+resource "aws_security_group_rule" "hmpp_route53_resolver_53_tcp" {
+  count = var.modernisation_platform_hmpp_domain_name != null ? 1 : 0
+
+  type              = "egress"
+  description       = "Allow outbound tcp/53"
+  from_port         = 53
+  to_port           = 53
+  protocol          = "tcp"
+  cidr_blocks       = ["0.0.0.0/0"]
+  security_group_id = aws_security_group.hmpp_route53_resolver[0].id
+}
+
+resource "aws_security_group_rule" "hmpp_route53_resolver_53_udp" {
+  count = var.modernisation_platform_hmpp_domain_name != null ? 1 : 0
+
+  type              = "egress"
+  description       = "Allow outbound udp/53"
+  from_port         = 53
+  to_port           = 53
+  protocol          = "udp"
+  cidr_blocks       = ["0.0.0.0/0"]
+  security_group_id = aws_security_group.hmpp_route53_resolver[0].id
+}
+
+resource "aws_route53_resolver_endpoint" "hmpp_route53_resolver" {
+  count = var.modernisation_platform_hmpp_domain_name != null ? 1 : 0
+
+  name               = "ForwardToHMPPDomainTF"
+  direction          = "OUTBOUND"
+  security_group_ids = [aws_security_group.hmpp_route53_resolver[0].id]
+
+  dynamic "ip_address" {
+    for_each = var.private_subnet_map
+
+    content {
+      subnet_id = ip_address.value
+    }
+  }
+
+  tags = merge(local.tags, {
+    Name = "ForwardToHMPPDomainTF"
+  })
+}
+
+resource "aws_route53_resolver_rule" "hmpp_route53_resolver_hmpp" {
+  count = var.modernisation_platform_hmpp_domain_name != null ? 1 : 0
+
+  domain_name = var.modernisation_platform_hmpp_domain_name
+  name        = "forward-to-hmpp-domain"
+  rule_type   = "FORWARD"
+
+  resolver_endpoint_id = aws_route53_resolver_endpoint.hmpp_route53_resolver[0].id
+
+  dynamic "target_ip" {
+    for_each = var.modernisation_platform_hmpp_dc_ips
+    content {
+      ip = target_ip.value
+    }
+  }
+
+  tags = merge(local.tags, {
+    Name = "forward-to-hmpp-domain"
+  })
+}
+
+resource "aws_route53_resolver_rule_association" "this" {
+  count = var.modernisation_platform_hmpp_domain_name != null ? 1 : 0
+
+  resolver_rule_id = aws_route53_resolver_rule.hmpp_route53_resolver_hmpp[0].id
+  vpc_id           = local.vpc_id
+}

--- a/modules/common/variables.tf
+++ b/modules/common/variables.tf
@@ -47,3 +47,17 @@ variable "modernisation_platform_hmpp_dc_cidr" {
   type    = string
   default = null
 }
+
+variable "modernisation_platform_hmpp_dc_ips" {
+  type    = list(string)
+  default = null
+}
+
+variable "modernisation_platform_hmpp_domain_name" {
+  type    = string
+  default = null
+}
+
+variable "private_subnet_map" {
+  type = map(any)
+}


### PR DESCRIPTION
Add Route53 resolver endpoint and related resources so azure.hmpp.root domain resolves on legacy EC2s. This will allow NART fileshare to be mounted for ndmis migration.