### PR TITLE
TM-2111: allow-nextcloud-smb-access-from-ndmis-in-mp

### DIFF
--- a/security-groups/nextcloud-rules.tf
+++ b/security-groups/nextcloud-rules.tf
@@ -233,6 +233,18 @@ resource "aws_security_group_rule" "samba_in" {
   self              = "true"
 }
 
+resource "aws_security_group_rule" "samba_in_cidrs" {
+  count = var.nextcloud_smb_access_cidrs != null ? 1 : 0
+
+  security_group_id = data.terraform_remote_state.security-groups.outputs.sg_mis_samba
+  from_port         = 445
+  to_port           = 445
+  protocol          = "tcp"
+  type              = "ingress"
+  description       = "Access to SMB from given CIDRs"
+  cidr_blocks       = var.nextcloud_smb_access_cidrs
+}
+
 resource "aws_security_group_rule" "samba_out" {
   security_group_id = data.terraform_remote_state.security-groups.outputs.sg_mis_samba
   from_port         = 445

--- a/security-groups/variables.tf
+++ b/security-groups/variables.tf
@@ -28,3 +28,9 @@ variable "bastion_remote_state_bucket_name" {
 variable "bastion_role_arn" {
   description = "role to access bastion terraform state"
 }
+
+variable "nextcloud_smb_access_cidrs" {
+  type        = list(string)
+  default     = null
+  description = "List of CIDRs allowed to access nextcloud SMB access"
+}


### PR DESCRIPTION
So NDMIS can be migrated independently of NextCloud