### PR TITLE
PLAT-54: ndmis: add probation prod URLs and validation records

### DIFF
--- a/ec2-ndl-bws/migration.tf
+++ b/ec2-ndl-bws/migration.tf
@@ -1,0 +1,29 @@
+resource "aws_route53_record" "modernisation_platform_reporting_cname" {
+  count = var.modernisation_platform_mis_cname != null ? 1 : 0
+
+  zone_id = local.public_zone_id
+  name    = "reporting.${local.external_domain}"
+  type    = "CNAME"
+  ttl     = 300
+  records = [var.modernisation_platform_mis_cname]
+}
+
+resource "aws_route53_record" "modernisation_platform_reporting_admin_cname" {
+  count = var.modernisation_platform_mis_cname != null ? 1 : 0
+
+  zone_id = local.public_zone_id
+  name    = "admin.reporting.${local.external_domain}"
+  type    = "CNAME"
+  ttl     = 300
+  records = ["admin.${var.modernisation_platform_mis_cname}"]
+}
+
+resource "aws_route53_record" "modernisation_platform_reporting_external_validation" {
+  count = var.modernisation_platform_mis_cert_validation_name != null ? 1 : 0
+
+  zone_id = local.public_zone_id
+  name    = var.modernisation_platform_mis_cert_validation_name
+  type    = "CNAME"
+  ttl     = 300
+  records = [var.modernisation_platform_mis_cert_validation_value]
+}

--- a/ec2-ndl-bws/variables.tf
+++ b/ec2-ndl-bws/variables.tf
@@ -113,3 +113,27 @@ variable "lb_management_rule_enabled" {
   type        = string
   default     = "false"
 }
+
+variable "modernisation_platform_mis_cname" {
+  description = "Optionally add an external CNAME record to the modernisation platform reporting URL"
+  type        = string
+  default     = null
+}
+
+variable "modernisation_platform_mis_admin_cname" {
+  description = "Optionally add an external CNAME record to the modernisation platform reporting admin URL"
+  type        = string
+  default     = null
+}
+
+variable "modernisation_platform_mis_cert_validation_name" {
+  description = "Modernisation platform cert External validation name"
+  type        = string
+  default     = null
+}
+
+variable "modernisation_platform_mis_cert_validation_value" {
+  description = "Modernisation platform cert External validation value"
+  type        = string
+  default     = null
+}


### PR DESCRIPTION
Add URLs for NDMIS prod and associated cert validation records, e.g. reporting.probation.service.justice.gov.uk

Already applied